### PR TITLE
fix: make DB healthcheck type-safe

### DIFF
--- a/src/Check/DatabaseCheck.php
+++ b/src/Check/DatabaseCheck.php
@@ -18,6 +18,6 @@ class DatabaseCheck extends Check implements CheckInterface
             ->executeQuery('SELECT 1 + 1 as result')
             ->fetchOne();
 
-        return $this->result('2' === $result);
+        return $this->result(2 === (int) $result);
     }
 }


### PR DESCRIPTION
- cast SQL result to int before comparison
- ensures consistent behavior across drivers